### PR TITLE
Expose port for artifacts server

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,5 +19,7 @@ services:
     image: ghcr.io/delvtech/infra/artifacts:0.0.1
     volumes:
       - artifacts:/var/www/artifacts/
+    ports:
+      - 80:80
 volumes:
   artifacts:


### PR DESCRIPTION
By exposing this port, clients (ie: the frontend) will be able to request artifacts (ie: addresses.json) from the server at `localhost:80`