### PR TITLE
Added profiles so that the frontend and bots can be toggled on and off

### DIFF
--- a/docker-compose.bots.yaml
+++ b/docker-compose.bots.yaml
@@ -7,6 +7,8 @@ services:
     # local elf-sims pointing to IHyperdrive
     # image: elf-sims:${ELFPY_TAG}
     image: ghcr.io/delvtech/elf-simulations/elf-sims:${ELFPY_TAG}
+    profiles:
+      - "bots"
     working_dir: /app/
     environment:
       - BOT_ALCHEMY=false

--- a/docker-compose.frontend.yaml
+++ b/docker-compose.frontend.yaml
@@ -3,6 +3,8 @@ services:
 
   hyperdrive-monorepo:
     image: ghcr.io/delvtech/hyperdrive-monorepo/hyperdrive-monorepo:${HYPERDRIVE_MONOREPO_TAG}
+    profiles:
+      - "frontend"
     environment:
       - VITE_ALCHEMY_GOERLI_RPC_KEY=${ALCHEMY_GOERLI_API_KEY}
       - VITE_LOCALHOST_NODE_RPC_URL=http://localhost:8545

--- a/env/env.tags
+++ b/env/env.tags
@@ -23,4 +23,4 @@ ARTIFACTS_TAG=0.0.2
 ELFPY_TAG=nightly-796d5906bfc7111b7a0f0b32160a986460b0b48f
 
 # hyperdrive-monorepo (frontend) - latest tagged (weekly) release
-HYPERDRIVE_MONOREPO_TAG=latest
+HYPERDRIVE_MONOREPO_TAG=nightly-15a4e64b44db1f77117021586be923e2b1289487


### PR DESCRIPTION
Docker Compose has a feature that allows services to be toggled using [profiles](https://docs.docker.com/compose/profiles/). This gives us an easy way of specifying what layers of the application we want to run (bots, frontend, etc.) without compromising on the maintainability of the environment variable files. 

An alternative solution would be to have a different "ports" compose file for each service; however, we get the same functionality with the approach used here and we don't have to create new compose files for every service added. 