### PR TITLE
Use bot server

### DIFF
--- a/docker-compose.bots.yaml
+++ b/docker-compose.bots.yaml
@@ -25,7 +25,7 @@ services:
       - BOT_TRADE_CHANCE=0.1
       - BOT_RPC_URL=http://ethereum:8545
 
-    command: "/bin/sh -c 'python examples/evm_bots.py'"
+    command: "/bin/sh -c 'python elfpy/bots/bots_server.py examples/evm_bots.py'"
 
 volumes:
   artifacts:


### PR DESCRIPTION
Corresponds to https://github.com/delvtech/elf-simulations/pull/555

We can now spin up a simple bot server that will create evm_bot processes.  This lets us put up a container in the cloud and then easily spin up/down different evm_bot processes.  