### PR TITLE
make local mount for contracts

### DIFF
--- a/docker-compose.devnet.yaml
+++ b/docker-compose.devnet.yaml
@@ -17,6 +17,8 @@ services:
       - RPC_URL=http://ethereum:8545
     volumes:
       - artifacts:/src/artifacts/
+      - ~/hyperdrive_solidity:/src/  # local mount for development
+
     # TODO: This is a band-aid solution for the memory leaks experienced on
     # Apple Silicon. Remove the restart policy when this reliably starts.
     restart: on-failure:5

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -72,6 +72,13 @@ full_compose_files="COMPOSE_FILE=$devnet_compose:$bot_compose:$frontend_compose:
 if $PORTS; then
     full_compose_files+="$ports_compose:"
 fi
+if $DEVNET; then  # ensure folder exists to map contracts to
+    # if folder doesn't exist make it and echo that
+    if [ ! -d ~/hyperdrive_solidity ]; then
+        mkdir ~/hyperdrive_solidity
+        echo "Created ~/hyperdrive_solidity"
+    fi
+fi
 
 # Check if ":" is at the end of the string
 if [[ $full_compose_files == *":" ]]; then


### PR DESCRIPTION
allow ape to compile from contracts inside docker
right now we have to have a local hyperdrive repo checked out and pointed to the right commit
this PR isn't currently working, since the migrations image goes down after its script runs