### PR TITLE
Bumped the Hyperdrive tag to 0.0.3

### DIFF
--- a/env/env.tags
+++ b/env/env.tags
@@ -1,20 +1,7 @@
 # Build tags for each container in the stack.
 
-# Hyperdrive (The one that actually gets used)
-HYPERDRIVE_TAG=nightly-5c244de4462c0fd02ef3a5556daeeb9f8c066fbc
-
-#####################################################################
-# NOTE: Comment-driven development section. Swap these in as needed.
-#
-# Description: v0.0.2
-# HYPERDRIVE_TAG=nightly-3188e7df62a07a77c61c467ab640aeec836c79fe
-#
-# Description: v0.0.2 w/ prints
-# HYPERDRIVE_TAG=nightly-62696e9a371da64aa0facf5865f580747a067d36
-#
-# Description: latest tagged version
-# HYPERDRIVE_TAG=latest
-#####################################################################
+# Hyperdrive
+HYPERDRIVE_TAG=0.0.3
 
 # Artifacts
 ARTIFACTS_TAG=0.0.2


### PR DESCRIPTION
Here are the release notes for Hyperdrive v0.0.3: https://github.com/delvtech/hyperdrive/releases/tag/v0.0.3. 