### PR TITLE
Add a service to mine the first block on the devnet

### DIFF
--- a/docker-compose.devnet.yaml
+++ b/docker-compose.devnet.yaml
@@ -1,6 +1,6 @@
 version: "3.9"
-
 services:
+
   ethereum:
     image: ghcr.io/delvtech/hyperdrive/devnet:${HYPERDRIVE_TAG}
     # without --block-time we're in "automine" mode and blocks are mined


### PR DESCRIPTION
When the chain is on block 0, we get overflow/underflow errors trying to make read calls to the contracts, so we mine the first block when starting the compose app to prevent this.