### PR TITLE
Adds a CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-# Ryan needs to approve every PR.
-* @ryangoree
+# All PRs must be approved by infra owners
+* @ryangoree @jalextowle @slundqui @jrhea


### PR DESCRIPTION
It's useful to have mandatory reviews for codebases like this that are important for operations. Here is some documentation on this feature of github: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners. I added Ryan as the sole codeowner, but it may make sense to add other people so that the process isn't blocked by a single reviewer.