### PR TITLE
Adds the checkpointing bot

### DIFF
--- a/docker-compose.data.yaml
+++ b/docker-compose.data.yaml
@@ -15,8 +15,8 @@ services:
       - .env
     # These environment variables are connecting to other necessary containers
     environment:
-      - CONTRACTS_URL=http://artifacts:${ARTIFACT_PORT}/addresses.json
-      - ETHEREUM_NODE=http://ethereum:${ETH_PORT}
+      - CONTRACTS_URL=${ARTIFACTS_URL}/addresses.json
+      - ETHEREUM_NODE=${RPC_URL}
 
   username-reg:
     image: ghcr.io/delvtech/elf-simulations/elf-simulations:${ELFPY_TAG}

--- a/docker-compose.devnet.yaml
+++ b/docker-compose.devnet.yaml
@@ -17,7 +17,7 @@ services:
     depends_on:
       - ethereum
     command: |
-      /bin/sh -c "sleep 1; curl -X POST -H \"Content-Type: application/json\" --data '{\"jsonrpc\":\"2.0\", \"method\":\"anvil_mine\", \"params\":[], \"id\":1}' http://ethereum:8545"
+      /bin/sh -c "sleep 1; curl -X POST -H \"Content-Type: application/json\" --data '{\"jsonrpc\":\"2.0\", \"method\":\"anvil_mine\", \"params\":[], \"id\":1}' ${RPC_URL}"
 
   # Set account balances
   fund-accounts:
@@ -40,7 +40,7 @@ services:
     depends_on:
       - ethereum
     command: |
-      /bin/sh -c "sleep 1; ARTIFACTS_URL=$ARTIFACTS_URL RPC_URL=$RPC_URL python elfpy/bots/checkpoint_bot.py"
+      /bin/sh -c "sleep 1; ARTIFACTS_URL=${ARTIFACTS_URL} RPC_URL=${RPC_URL} python elfpy/bots/checkpoint_bot.py"
 
 volumes:
   artifacts:

--- a/env/env.common
+++ b/env/env.common
@@ -1,0 +1,3 @@
+# Networking configuration
+ARTIFACTS_URL=http://artifacts:80
+RPC_URL=http://ethereum:8545

--- a/env/env.devnet
+++ b/env/env.devnet
@@ -1,6 +1,2 @@
 # Choose a chain id for the eth node
 CHAIN_ID=42069
-
-# Networking configuration for the checkpoint bot.
-ARTIFACTS_URL=http://artifacts:80
-RPC_URL=http://ethereum:8545

--- a/env/env.ports
+++ b/env/env.ports
@@ -1,5 +1,4 @@
-# Specify the local ports that should be open
-
+# The ports that should be opened if the --ports option is used.
 ETH_PORT=8545
 ARTIFACT_PORT=80
 UI_PORT=5173

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -132,19 +132,15 @@ fi
 # Append the COMPOSE_PROFILES environment variable to the .env file
 echo $full_compose_profiles >>.env
 
-# cat env.tags to the .env file
+# cat env.common, env.tags, and env.ports to the .env file
+cat env/env.common >> .env
 cat env/env.tags >>.env
+cat env/env.ports >>.env
 
 # optionally cat env.devnet to .env file if --devnet
 if $DEVNET; then
     echo $'\n' >>.env
     cat env/env.devnet >>.env
-fi
-
-# optionally cat env.ports to .env file if --ports
-if $PORTS; then
-    echo $'\n' >>.env
-    cat env/env.ports >>.env
 fi
 
 # optionally add an env.frontend to .env file if --frontend


### PR DESCRIPTION
This PR adds a service that will poll the Hyperdrive contracts to see whether or not a checkpoint should be minted. This will help to ensure that every checkpoint is minted, which prevents accounting issues from occurring.

The checkpointing bot's code needs to be pushed in a tagged image (currently it's only supported on `edge`) for this to be used. 