### PR TITLE
Removing data to eth dependency from docker compose

### DIFF
--- a/docker-compose.data.yaml
+++ b/docker-compose.data.yaml
@@ -7,9 +7,6 @@ services:
       - "data"
     working_dir: /app/
     command: /bin/sh -c "python elfpy/data/acquire_data.py"
-    depends_on:
-      - ethereum
-      - artifacts
     # This file sets postgres information
     env_file:
       - .env


### PR DESCRIPTION
The data container, which is responsible for querying the chain and writing data to postgres, previously depended on the ethereum container. A side effect of this was that restarting the data container also restarts the ethereum container. This dependency isn't strictly necessary, because the data container is able to handle starting/stopping independent to the ethereum container. By removing the dependency, it allows for live updates to the data container without rebooting the ethereum container.