### PR TITLE
Add comment on `CHAIN_ID` env variable

### DIFF
--- a/env/env.anvil
+++ b/env/env.anvil
@@ -1,2 +1,3 @@
 # Choose a chain id for the eth node
+# Common choices are: 42069 for CloudChain or 31337 for local development
 CHAIN_ID=42069


### PR DESCRIPTION
Frontend devs have to toggle this .env variable between CloudChain and localhost chain for development, but the default is set to CloudChain. Most of the time we're running against localhost though, so this comment minimizes the risk of overlooking this detail when pulling the latest changes after an extended absence.